### PR TITLE
Release player from containing it activity

### DIFF
--- a/giraffeplayer2/src/main/java/tcking/github/com/giraffeplayer2/PlayerManager.java
+++ b/giraffeplayer2/src/main/java/tcking/github/com/giraffeplayer2/PlayerManager.java
@@ -115,7 +115,7 @@ public class PlayerManager {
 
             @Override
             public void onActivityDestroyed(Activity activity) {
-                GiraffePlayer currentPlayer = getCurrentPlayer();
+                GiraffePlayer currentPlayer = getPlayerByFingerprint(activity2playersRef.get(activity));
                 if (currentPlayer != null) {
                     currentPlayer.onActivityDestroyed();
                 }


### PR DESCRIPTION
Previously player was released when any other activity was destroyed.