### PR TITLE
Override media controller

### DIFF
--- a/giraffeplayer2/src/main/java/tcking/github/com/giraffeplayer2/VideoView.java
+++ b/giraffeplayer2/src/main/java/tcking/github/com/giraffeplayer2/VideoView.java
@@ -91,7 +91,7 @@ public class VideoView extends FrameLayout{
     }
 
     @NonNull
-    protected DefaultMediaController createMediaController() {
+    protected MediaController createMediaController() {
         return new DefaultMediaController(getContext());
     }
 

--- a/giraffeplayer2/src/main/java/tcking/github/com/giraffeplayer2/VideoView.java
+++ b/giraffeplayer2/src/main/java/tcking/github/com/giraffeplayer2/VideoView.java
@@ -86,8 +86,13 @@ public class VideoView extends FrameLayout{
 
 
     private void initMediaController() {
-        mediaController = new DefaultMediaController(getContext());
+        mediaController = createMediaController();
         mediaController.bind(this);
+    }
+
+    @NonNull
+    protected DefaultMediaController createMediaController() {
+        return new DefaultMediaController(getContext());
     }
 
 


### PR DESCRIPTION
Currently it is quite easy to customize the player on the level of DefaultMediaController (almost anything is protected) and BaseMediaController

However, the VideoView itself is bind to a single implementation, so requires a copy-paste of it + impossibility to reuse BaseMediaController or it's implementation due to fact that BaseMediaController.bind is binded to VideoView class itself.

So the solution is to allow to allow another child of VideoView to create a different instance of BaseMediaController