### PR TITLE
Fix bugs inner element must either be a resource reference or empty follow this ref https://developer.android.com/guide/topics/resources/more-resources#Id

### DIFF
--- a/giraffeplayer2/src/main/res/values/ids.xml
+++ b/giraffeplayer2/src/main/res/values/ids.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <item name="player_display" type="id">player_display</item>
-    <item name="player_display_box" type="id">player_display_box</item>
-    <item name="player_display_float_box" type="id">player_display_float_box</item>
+    <item name="player_display" type="id"/>
+    <item name="player_display_box" type="id"/>
+    <item name="player_display_float_box" type="id"/>
 </resources>


### PR DESCRIPTION
Reference from Android Doc: https://developer.android.com/guide/topics/resources/more-resources#Id
It just has a problem when you're using API 28
Please approve my pull request for next release
Isssue: https://github.com/tcking/GiraffePlayer2/issues/130